### PR TITLE
Being defensive (for bundlers) when checking module.parent.uniqid_debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function now(){
 }
 
 function macHandler(error){
-    if(module.parent.uniqid_debug){
+    if(module.parent && module.parent.uniqid_debug){
         if(error) console.error('Info: No mac address - uniqid() falls back to uniqid.process().', error)
         if(pid == '') console.error('Info: No process.pid - uniqid.process() falls back to uniqid.time().')
     }


### PR DESCRIPTION
Neither webpack nor jspm support `module.parent`, which causes problems when bundling uniqid. In the case of jspm, even when uniqid is just a build tool (that's helping bundle other things but is not even being bundled itself), it will throw errors since jspm/systemjs build tools run inside of a controlled non-cjs environment. See https://github.com/webpack/webpack/issues/1569, https://github.com/jspm/jspm-cli/issues/2134, and https://github.com/systemjs/systemjs/issues/1470.

This change simply is to be defensive so that uniqid doesn't die when it is running in the browser or an environment that doesn't have full cjs support (like webpack and jspm)