### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/adamhalasz/uniqid.git"
   },
+  "files": [
+    "index.js"
+  ],
   "license": "MIT",
   "author": {
     "name": "Halász Ádám",


### PR DESCRIPTION
Prevents `examples` from being published to NPM.  Saves 20-some KB from the package size.