### PR TITLE
Fix vite 3 warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // ================================================
 var pid = typeof process !== 'undefined' && process.pid ? process.pid.toString(36) : '' ;
 var address = '';
-if(typeof __webpack_require__ !== 'function' && typeof require !== 'undefined'){
+if(typeof __webpack_require__ !== 'function' && typeof global !== 'undefined'){
     var mac = '', os = require('os'); 
     if(os.networkInterfaces) var networkInterfaces = os.networkInterfaces();
     if(networkInterfaces){


### PR DESCRIPTION
Vite 3 show warning in console 
`Module "os" has been externalized for browser compatibility. Cannot access "os.networkInterfaces" in client code.`

It replace `require` to `__require` in `.vite/deps/uniqid.js`, so that check is always true as `__require` is defined there.